### PR TITLE
apiVersion do not match the group and version of the CRD

### DIFF
--- a/charts/secrets-store-csi-driver/templates/csidriver.yaml
+++ b/charts/secrets-store-csi-driver/templates/csidriver.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: csi.storage.k8s.io/v1alpha1
 kind: CSIDriver
 metadata:
   name: secrets-store.csi.k8s.com


### PR DESCRIPTION
There is a mismatch between the deployed CRD (group and version) and the api version used on the CSI.