### PR TITLE
Redact access token and client id in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,12 @@ csi-secrets-store-secrets-store-csi-driver-pcbtg   2/2       Running   0        
 <summary><strong>[ALTERNATIVE DEPLOYMENT OPTION] Using Deployment Yamls</strong></summary>
 
 ```bash
-kubectl apply -f deploy/crd-csi-driver-registry.yaml
-kubectl apply -f deploy/rbac-csi-driver-registrar.yaml
-kubectl apply -f deploy/rbac-csi-attacher.yaml
-kubectl apply -f deploy/csi-secrets-store-attacher.yaml
-kubectl apply -f deploy/secrets-store-csi-driver.yaml
-kubectl apply -f deploy/csidriver.yaml
+kubectl apply -f https://raw.githubusercontent.com/deislabs/secrets-store-csi-driver/master/deploy/crd-csi-driver-registry.yaml
+kubectl apply -f https://raw.githubusercontent.com/deislabs/secrets-store-csi-driver/master/deploy/rbac-csi-driver-registrar.yaml
+kubectl apply -f https://raw.githubusercontent.com/deislabs/secrets-store-csi-driver/master/deploy/rbac-csi-attacher.yaml
+kubectl apply -f https://raw.githubusercontent.com/deislabs/secrets-store-csi-driver/master/deploy/csi-secrets-store-attacher.yaml
+kubectl apply -f https://raw.githubusercontent.com/deislabs/secrets-store-csi-driver/master/deploy/secrets-store-csi-driver.yaml
+kubectl apply -f https://raw.githubusercontent.com/deislabs/secrets-store-csi-driver/master/deploy/csidriver.yaml
 ```
 To validate the installer is running as expected, run the following commands:
 

--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -36,7 +36,7 @@ spec:
         - name: secrets-store
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           args:
-            - "--v=5"
+            - "--v=3"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"
           env:

--- a/deploy/secrets-store-csi-driver.yaml
+++ b/deploy/secrets-store-csi-driver.yaml
@@ -28,14 +28,14 @@ spec:
                   fieldPath: spec.nodeName
           imagePullPolicy: Always
           volumeMounts:
-          - mountPath: /csi
-            name: socket-dir
-          - mountPath: /registration
-            name: registration-dir
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /registration
+              name: registration-dir
         - name: secrets-store
           image: ritazh/secrets-store-csi:v0.0.4
           args:
-            - "--v=5"
+            - "--v=3"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"
           env:

--- a/pkg/providers/azure/provider.go
+++ b/pkg/providers/azure/provider.go
@@ -262,7 +262,7 @@ func (p *Provider) GetServicePrincipalToken(env *azure.Environment, resource str
 				return nil, err
 			}
 
-			r, _ := regexp.Compile("^(\\S{4})(\\S|\\s)*(\\S{4})$")
+			r, _ := regexp.Compile(`^(\S{4})(\S|\s)*(\S{4})$`)
 			glog.V(0).Infof("accesstoken: %s", r.ReplaceAllString(nmiResp.Token.AccessToken, "$1##### REDACTED #####$3"))
 			glog.V(0).Infof("clientid: %s", r.ReplaceAllString(nmiResp.ClientID, "$1##### REDACTED #####$3"))
 

--- a/pkg/providers/azure/provider.go
+++ b/pkg/providers/azure/provider.go
@@ -262,7 +262,7 @@ func (p *Provider) GetServicePrincipalToken(env *azure.Environment, resource str
 				return nil, err
 			}
 
-			r, _ := regexp.Compile(`^(S{4})(S|s)*(S{4})$`)
+			r, _ := regexp.Compile("^(\\S{4})(\\S|\\s)*(\\S{4})$")
 			glog.V(0).Infof("accesstoken: %s", r.ReplaceAllString(nmiResp.Token.AccessToken, "$1##### REDACTED #####$3"))
 			glog.V(0).Infof("clientid: %s", r.ReplaceAllString(nmiResp.ClientID, "$1##### REDACTED #####$3"))
 
@@ -386,8 +386,6 @@ func (p *Provider) MountSecretsStoreObjectContent(ctx context.Context, attrib ma
 
 // GetKeyVaultObjectContent get content of the keyvault object
 func (p *Provider) GetKeyVaultObjectContent(ctx context.Context, objectType string, objectName string, objectVersion string) (content string, err error) {
-	// TODO: support pod identity
-
 	vaultURL, err := p.getVaultURL(ctx, "")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get vault")

--- a/pkg/providers/vault/provider.go
+++ b/pkg/providers/vault/provider.go
@@ -61,7 +61,7 @@ type StringArray struct {
 
 // NewProvider creates a new provider HashiCorp Vault.
 func NewProvider() (*Provider, error) {
-	glog.V(2).Infof("NewProvider")
+	glog.V(2).Infof("NewVaultProvider")
 	var p Provider
 	return &p, nil
 }


### PR DESCRIPTION
- Redact access token and client id in Azure provider pod identity scenario
- Reduce log verbosity in deployment
- Update to raw urls

Fixes https://github.com/deislabs/secrets-store-csi-driver/issues/53