### PR TITLE
redact clientid and secret in logs

### DIFF
--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -45,7 +45,7 @@ spec:
         - name: secrets-store
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           args:
-            - "--v=5"
+            - "--v=3"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"
           env:

--- a/deploy/secrets-store-csi-driver.yaml
+++ b/deploy/secrets-store-csi-driver.yaml
@@ -44,7 +44,7 @@ spec:
         - name: secrets-store
           image: docker.io/deislabs/secrets-store-csi:v0.0.5
           args:
-            - "--v=5"
+            - "--v=3"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"
           env:

--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -106,7 +106,7 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 }
 
 func logRedactedRequest(req interface{}) {
-	re, _ := regexp.Compile("^(\\S{4})(\\S|\\s)*(\\S{4})$")
+	re, _ := regexp.Compile(`^(\\S{4})(\\S|\\s)*(\\S{4})$`)
 
 	r, ok := req.(*csi.NodePublishVolumeRequest)
 	if !ok {

--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -18,6 +18,7 @@ package csicommon
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -94,7 +95,7 @@ func RunControllerandNodePublishServer(endpoint string, d *CSIDriver, cs csi.Con
 
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	glog.V(3).Infof("GRPC call: %s", info.FullMethod)
-	glog.V(5).Infof("GRPC request: %+v", req)
+	logRedactedRequest(req)
 	resp, err := handler(ctx, req)
 	if err != nil {
 		glog.Errorf("GRPC error: %v", err)
@@ -102,4 +103,29 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 		glog.V(5).Infof("GRPC response: %+v", resp)
 	}
 	return resp, err
+}
+
+func logRedactedRequest(req interface{}) {
+	re, _ := regexp.Compile("^(\\S{4})(\\S|\\s)*(\\S{4})$")
+
+	r, ok := req.(*csi.NodePublishVolumeRequest)
+	if !ok {
+		glog.V(5).Infof("GRPC request: %+v", req)
+		return
+	}
+
+	req1 := *r
+	redactedSecrets := make(map[string]string)
+
+	secrets := req1.GetSecrets()
+	for k, v := range secrets {
+		switch k {
+		case "clientid", "clientsecret":
+			redactedSecrets[k] = re.ReplaceAllString(v, "$1##### REDACTED #####$3")
+		default:
+			redactedSecrets[k] = v
+		}
+	}
+	req1.Secrets = redactedSecrets
+	glog.V(5).Infof("GRPC request: %+v", req1)
 }

--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -106,7 +106,7 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 }
 
 func logRedactedRequest(req interface{}) {
-	re, _ := regexp.Compile(`^(\\S{4})(\\S|\\s)*(\\S{4})$`)
+	re, _ := regexp.Compile(`^(\S{4})(\S|\s)*(\S{4})$`)
 
 	r, ok := req.(*csi.NodePublishVolumeRequest)
 	if !ok {

--- a/pkg/providers/azure/provider.go
+++ b/pkg/providers/azure/provider.go
@@ -262,7 +262,7 @@ func (p *Provider) GetServicePrincipalToken(env *azure.Environment, resource str
 				return nil, err
 			}
 
-			r, _ := regexp.Compile(`^(S{4})(S|s)*(S{4})$`)
+			r, _ := regexp.Compile(`^(\S{4})(\S|\s)*(\S{4})$`)
 			glog.V(0).Infof("accesstoken: %s", r.ReplaceAllString(nmiResp.Token.AccessToken, "$1##### REDACTED #####$3"))
 			glog.V(0).Infof("clientid: %s", r.ReplaceAllString(nmiResp.ClientID, "$1##### REDACTED #####$3"))
 
@@ -389,8 +389,6 @@ func (p *Provider) MountSecretsStoreObjectContent(ctx context.Context, attrib ma
 
 // GetKeyVaultObjectContent get content of the keyvault object
 func (p *Provider) GetKeyVaultObjectContent(ctx context.Context, objectType string, objectName string, objectVersion string) (content string, err error) {
-	// TODO: support pod identity
-
 	vaultURL, err := p.getVaultURL(ctx, "")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get vault")

--- a/pkg/providers/vault/provider.go
+++ b/pkg/providers/vault/provider.go
@@ -61,7 +61,7 @@ type StringArray struct {
 
 // NewProvider creates a new provider HashiCorp Vault.
 func NewProvider() (*Provider, error) {
-	glog.V(2).Infof("NewProvider")
+	glog.V(2).Infof("NewVaultProvider")
 	var p Provider
 	return &p, nil
 }


### PR DESCRIPTION
- Redact client id and secret in GRPC request log
- Redact access token and client id in Azure provider pod identity scenario
- Reduce log verbosity in deployment

Fixes #53 

Example log:

```
I0906 19:58:02.943210       1 utils.go:130] GRPC request: {VolumeId:csi-ff1aba1aefda574ea47d04fecff1ff4d2724eb6d43878da6cc1f29d908283576 PublishContext:map[] StagingTargetPath: TargetPath:/var/lib/kubelet/pods/f2a9a247-47d7-4718-8b45-ab4ec531d897/volumes/kubernetes.io~csi/secrets-store-inline/mount VolumeCapability:mount:<> access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:true Secrets:map[clientid:6009##### REDACTED #####f3eb clientsecret:162e##### REDACTED #####0c8c] VolumeContext:map[csi.storage.k8s.io/pod.name:nginx-secrets-store-inline-pod-identity csi.storage.k8s.io/pod.namespace:default csi.storage.k8s.io/pod.uid:f2a9a247-47d7-4718-8b45-ab4ec531d897 csi.storage.k8s.io/serviceAccount.name:default keyvaultName:vmss01 objects:array:
```