### PR TITLE
enable azure provider for e2e

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,23 +252,12 @@ Providers must provide the following functionality to be considered a supported 
 1. Does not have access to the Kubernetes APIs and has a well-defined callback mechanism to mount objects to a target path.
 
 - Supported Providers:
-  - [Azure Key Vault Provider](pkg/providers/azure)
-  - [HashiCorp Vault Provider](pkg/providers/vault)
+  - [Azure Key Vault Provider](https://github.com/Azure/secrets-store-csi-driver-provider-azure)
+  - [HashiCorp Vault Provider](https://github.com/hashicorp/secrets-store-csi-driver-provider-vault)
 
 ### Adding a New Provider via the Provider Interface
 
-Create a new directory for your provider under `providers` and implement the following interface.
-Then add your provider in `providers/register/provider_<provider_name>.go`. Make sure to add a build tag so that
-your provider can be excluded from being built. The format for this build tag
-should be `no_<provider_name>_provider`.
-
-```go
-// Provider contains the methods required to implement a Secrets Store CSI Driver provider.
-type Provider interface {
-    // MountSecretsStoreObjectContent mounts content of the secrets store object to target path
-    MountSecretsStoreObjectContent(ctx context.Context, attrib map[string]string, secrets map[string]string, targetPath string, permission os.FileMode) error
-}
-```
+_WIP_
 
 ## Testing
 

--- a/charts/secrets-store-csi-driver/values.yaml
+++ b/charts/secrets-store-csi-driver/values.yaml
@@ -20,5 +20,5 @@ providers:
   vault:
     enabled: false
     repository: hashicorp/secrets-store-csi-driver-provider-vault
-    tag: 0.0.1
+    tag: 0.0.2
     imagePullPolicy: Always

--- a/deploy/provider-vault.yaml
+++ b/deploy/provider-vault.yaml
@@ -15,7 +15,7 @@ spec:
       tolerations:
       containers:
         - name: provider-vault-installer
-          image: hashicorp/secrets-store-csi-driver-provider-vault:0.0.1
+          image: hashicorp/secrets-store-csi-driver-provider-vault:0.0.2
           imagePullPolicy: Always
           resources:
             requests:

--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -24,6 +24,7 @@ setup() {
           --set image.pullPolicy="IfNotPresent" \
           --set image.repository="e2e/secrets-store-csi" \
           --set image.tag=$IMAGE_TAG
+          --set providers.azure.enabled=true
   assert_success
 }
 


### PR DESCRIPTION
- Enable azure providers for azure e2e tests
- Update provider url 
- Bump vault provider to `0.0.2` version