### PR TITLE
check is mounted before unmount

### DIFF
--- a/cmd/secrets-store-csi-driver/main.go
+++ b/cmd/secrets-store-csi-driver/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"flag"
-	"os"
 
 	log "github.com/sirupsen/logrus"
 
@@ -49,7 +48,6 @@ func main() {
 	log.SetReportCaller(*logReportCaller)
 
 	handle()
-	os.Exit(0)
 }
 
 func handle() {

--- a/pkg/secrets-store/nodeserver.go
+++ b/pkg/secrets-store/nodeserver.go
@@ -231,6 +231,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			return nil, fmt.Errorf("error mounting secret %v", stderr.String())
 		}
 	} else {
+		// mock provider is used only for running sanity tests against the driver
 		err = mounter.Mount("tmpfs", targetPath, "tmpfs", []string{})
 		if err != nil {
 			log.Errorf("mount err: %v", err)
@@ -241,8 +242,12 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	notMnt, err = mount.New("").IsLikelyNotMountPoint(targetPath)
 	if err != nil {
-		log.Errorf("Error checking IsLikelyNotMountPoint: %v", err)
+		log.Errorf("Error checking targetPath %s IsLikelyNotMountPoint: %v", targetPath, err)
 		return nil, err
+	}
+	// this means the mount didn't succeed
+	if notMnt {
+		return nil, fmt.Errorf("after MountSecretsStoreObjectContent, notMnt: %v", notMnt)
 	}
 	log.Debugf("after MountSecretsStoreObjectContent, notMnt: %v", notMnt)
 	return &csi.NodePublishVolumeResponse{}, nil
@@ -260,14 +265,30 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	targetPath := req.GetTargetPath()
 	volumeID := req.GetVolumeId()
 
+	// check if target path is mount point
+	notMnt, err := mount.New("").IsLikelyNotMountPoint(targetPath)
+	if (err != nil && os.IsNotExist(err)) || notMnt {
+		log.Infof("target path %s is not likely a mount point, notMnt %v", targetPath, notMnt)
+		return &csi.NodeUnpublishVolumeResponse{}, nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	// if mount point, ensure mount link is still valid
+	if !notMnt {
+		if _, err = ioutil.ReadDir(targetPath); err != nil {
+			log.Infof("secrets-store not mounted to target path %s", targetPath)
+			return &csi.NodeUnpublishVolumeResponse{}, nil
+		}
+	}
+
 	// Unmounting the target
-	err := mount.New("").Unmount(req.GetTargetPath())
+	err = mount.New("").Unmount(targetPath)
 	if err != nil {
 		log.Errorf("error unmounting target path %s, err: %v", targetPath, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	log.Debugf("secrets-store: targetPath %s volumeID %s has been unmounted.", targetPath, volumeID)
-
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }
 


### PR DESCRIPTION
- Check if mounted before unmount 
- Use results of `IsLikelyNotMount` after node publish volume is complete.

Fixes #123, #106 