### PR TITLE
Update api to x-k8s

### DIFF
--- a/charts/secrets-store-csi-driver/templates/role.yaml
+++ b/charts/secrets-store-csi-driver/templates/role.yaml
@@ -7,6 +7,7 @@ metadata:
 rules:
 - apiGroups:
   - secrets-store.csi.k8s.com
+  - secrets-store.csi.x-k8s.io
   resources:
   - secretproviderclasses
   verbs:

--- a/charts/secrets-store-csi-driver/templates/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -1,0 +1,56 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: secretproviderclasses.secrets-store.csi.x-k8s.io
+spec:
+  group: secrets-store.csi.x-k8s.io
+  names:
+    kind: SecretProviderClass
+    plural: secretproviderclasses
+  scope: ""
+  validation:
+    openAPIV3Schema:
+      description: SecretProviderClass is the Schema for the secretproviderclasses
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SecretProviderClassSpec defines the desired state of SecretProviderClass
+          properties:
+            parameters:
+              additionalProperties:
+                type: string
+              description: Configuration for specific provider
+              type: object
+            provider:
+              description: Configuration for provider name
+              type: string
+          type: object
+        status:
+          description: SecretProviderClassStatus defines the observed state of SecretProviderClass
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/rbac-secretproviderclass.yaml
+++ b/deploy/rbac-secretproviderclass.yaml
@@ -24,6 +24,7 @@ metadata:
 rules:
 - apiGroups:
   - secrets-store.csi.k8s.com
+  - secrets-store.csi.x-k8s.io
   resources:
   - secretproviderclasses
   verbs:

--- a/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -1,0 +1,56 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: secretproviderclasses.secrets-store.csi.x-k8s.io
+spec:
+  group: secrets-store.csi.x-k8s.io
+  names:
+    kind: SecretProviderClass
+    plural: secretproviderclasses
+  scope: ""
+  validation:
+    openAPIV3Schema:
+      description: SecretProviderClass is the Schema for the secretproviderclasses
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SecretProviderClassSpec defines the desired state of SecretProviderClass
+          properties:
+            parameters:
+              additionalProperties:
+                type: string
+              description: Configuration for specific provider
+              type: object
+            provider:
+              description: Configuration for provider name
+              type: string
+          type: object
+        status:
+          description: SecretProviderClassStatus defines the observed state of SecretProviderClass
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/secrets-store/nodeserver.go
+++ b/pkg/secrets-store/nodeserver.go
@@ -109,7 +109,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		parameters = attrib
 	} else {
 		secretProviderClassGvk := schema.GroupVersionKind{
-			Group:   "secrets-store.csi.k8s.com",
+			Group:   "secrets-store.csi.x-k8s.io",
 			Version: "v1alpha1",
 			Kind:    "SecretProviderClassList",
 		}

--- a/secretProviderClass/Makefile
+++ b/secretProviderClass/Makefile
@@ -29,7 +29,7 @@ vet:
 # download controller-gen if necessary
 controller-gen:
 ifeq (, $(shell which controller-gen))
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.0-rc.0
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.2
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)

--- a/secretProviderClass/PROJECT
+++ b/secretProviderClass/PROJECT
@@ -1,3 +1,3 @@
 version: "2"
-domain: secrets-store.csi.k8s.com
+domain: secrets-store.csi.x-k8s.io
 repo: github.com/deislabs/secrets-store-csi-driver

--- a/secretProviderClass/api/v1alpha1/groupversion_info.go
+++ b/secretProviderClass/api/v1alpha1/groupversion_info.go
@@ -3,7 +3,7 @@
 
 // Package v1alpha1 contains API Schema definitions for the provider v1alpha1 API group
 // +kubebuilder:object:generate=true
-// +groupName=secrets-store.csi.k8s.com
+// +groupName=secrets-store.csi.x-k8s.io
 package v1alpha1
 
 import (
@@ -13,7 +13,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "secrets-store.csi.k8s.com", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "secrets-store.csi.x-k8s.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/secretProviderClass/config/crd/bases/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/secretProviderClass/config/crd/bases/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -3,12 +3,17 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: secretproviderclasses.secrets-store.csi.k8s.com
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.2
+  creationTimestamp: null
+  name: secretproviderclasses.secrets-store.csi.x-k8s.io
 spec:
-  group: secrets-store.csi.k8s.com
+  group: secrets-store.csi.x-k8s.io
   names:
     kind: SecretProviderClass
+    listKind: SecretProviderClassList
     plural: secretproviderclasses
+    singular: secretproviderclass
   scope: ""
   validation:
     openAPIV3Schema:

--- a/secretProviderClass/config/rbac/role.yaml
+++ b/secretProviderClass/config/rbac/role.yaml
@@ -6,7 +6,7 @@ metadata:
   name: secretproviderclasses-role
 rules:
 - apiGroups:
-  - secrets-store.csi.k8s.com
+  - secrets-store.csi.x-k8s.io
   resources:
   - secretproviderclasses
   verbs:

--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -55,20 +55,20 @@ setup() {
 }
 
 @test "secretproviderclasses crd is established" {
-  cmd="kubectl wait --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.csi.k8s.com"
+  cmd="kubectl wait --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.csi.x-k8s.io"
   wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
 
-  run kubectl get crd/secretproviderclasses.secrets-store.csi.k8s.com
+  run kubectl get crd/secretproviderclasses.secrets-store.csi.x-k8s.io
   assert_success
 }
 
 @test "deploy azure secretproviderclass crd" {
   envsubst < $BATS_TESTS_DIR/azure_v1alpha1_secretproviderclass.yaml | kubectl apply -f -
 
-  cmd="kubectl wait --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.csi.k8s.com"
+  cmd="kubectl wait --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.csi.x-k8s.io"
   wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
 
-  cmd="kubectl get secretproviderclasses.secrets-store.csi.k8s.com/azure -o yaml | grep azure"
+  cmd="kubectl get secretproviderclasses.secrets-store.csi.x-k8s.io/azure -o yaml | grep azure"
   wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
 }
 

--- a/test/bats/tests/azure_v1alpha1_secretproviderclass.yaml
+++ b/test/bats/tests/azure_v1alpha1_secretproviderclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: secrets-store.csi.k8s.com/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
 metadata:
   name: azure

--- a/test/bats/tests/vault_v1alpha1_secretproviderclass.yaml
+++ b/test/bats/tests/vault_v1alpha1_secretproviderclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: secrets-store.csi.k8s.com/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
 metadata:
   name: vault-foo

--- a/test/bats/vault.bats
+++ b/test/bats/vault.bats
@@ -98,10 +98,10 @@ EOF
 }
 
 @test "secretproviderclasses crd is established" {
-  cmd="kubectl wait --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.csi.k8s.com"
+  cmd="kubectl wait --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.x-k8s.io"
   wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
 
-  run kubectl get crd/secretproviderclasses.secrets-store.csi.k8s.com
+  run kubectl get crd/secretproviderclasses.secrets-store.csi.x-k8s.io
   assert_success
 }
 
@@ -110,10 +110,10 @@ EOF
 
   envsubst < $BATS_TESTS_DIR/vault_v1alpha1_secretproviderclass.yaml | kubectl apply -f -
 
-  cmd="kubectl wait --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.csi.k8s.com"
+  cmd="kubectl wait --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.csi.x-k8s.io"
   wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
 
-  cmd="kubectl get secretproviderclasses.secrets-store.csi.k8s.com/vault-foo -o yaml | grep vault"
+  cmd="kubectl get secretproviderclasses.secrets-store.csi.x-k8s.io/vault-foo -o yaml | grep vault"
   wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
 }
 

--- a/test/bats/vault.bats
+++ b/test/bats/vault.bats
@@ -98,7 +98,7 @@ EOF
 }
 
 @test "secretproviderclasses crd is established" {
-  cmd="kubectl wait --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.x-k8s.io"
+  cmd="kubectl wait --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.csi.x-k8s.io"
   wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
 
   run kubectl get crd/secretproviderclasses.secrets-store.csi.x-k8s.io


### PR DESCRIPTION
Fixes #112 

NOTE: will remove references of crd `secretproviderclasses.secrets-store.csi.k8s.com` after we make a new release and push a new image tag.