### PR TITLE
bump provider versions

### DIFF
--- a/charts/secrets-store-csi-driver/values.yaml
+++ b/charts/secrets-store-csi-driver/values.yaml
@@ -21,5 +21,5 @@ providers:
   vault:
     enabled: false
     repository: hashicorp/secrets-store-csi-driver-provider-vault
-    tag: 0.0.3
+    tag: 0.0.4
     imagePullPolicy: Always

--- a/charts/secrets-store-csi-driver/values.yaml
+++ b/charts/secrets-store-csi-driver/values.yaml
@@ -15,7 +15,7 @@ providers:
   azure:
     enabled: false
     repository: mcr.microsoft.com/k8s/csi/secrets-store/provider-azure
-    tag: 0.0.2
+    tag: 0.0.3
     imagePullPolicy: Always
 
   vault:

--- a/deploy/provider-azure.yaml
+++ b/deploy/provider-azure.yaml
@@ -18,7 +18,7 @@ spec:
       tolerations:
       containers:
         - name: provider-azure-installer
-          image: mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.2
+          image: mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.3
           imagePullPolicy: Always
           resources:
             requests:

--- a/deploy/provider-vault.yaml
+++ b/deploy/provider-vault.yaml
@@ -18,7 +18,7 @@ spec:
       tolerations:
       containers:
         - name: provider-vault-installer
-          image: hashicorp/secrets-store-csi-driver-provider-vault:0.0.3
+          image: hashicorp/secrets-store-csi-driver-provider-vault:0.0.4
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
Bump provider versions in prep for new driver release that will support driver-provider compatibility check. 

```
root@k8s-agentpool1-32372105-vmss000000:/# ./etc/kubernetes/secrets-store-csi-providers/azure/provider-azure --version
{"version":"0.0.3","buildDate":"2019-12-13-01:49","minDriverVersion":"v0.0.8"}
root@k8s-agentpool1-32372105-vmss000000:/# ./etc/kubernetes/secrets-store-csi-providers/vault/provider-vault --version
{"version":"0.0.4","buildDate":"2019-12-12-16:41","minDriverVersion":"v0.0.8"}
```