### PR TITLE
Remove categories for secretproviderclasses

### DIFF
--- a/charts/secrets-store-csi-driver/templates/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -11,9 +11,6 @@ spec:
     listKind: SecretProviderClassList
     plural: secretproviderclasses
     singular: secretproviderclass
-    categories:
-    - all
-    - secretproviderclass
   scope: ""
   validation:
     openAPIV3Schema:

--- a/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -11,9 +11,6 @@ spec:
     listKind: SecretProviderClassList
     plural: secretproviderclasses
     singular: secretproviderclass
-    categories:
-    - all
-    - secretproviderclass
   scope: ""
   validation:
     openAPIV3Schema:

--- a/secretProviderClass/config/crd/bases/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/secretProviderClass/config/crd/bases/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -13,9 +13,6 @@ spec:
     listKind: SecretProviderClassList
     plural: secretproviderclasses
     singular: secretproviderclass
-    categories:
-    - all
-    - secretproviderclass
   scope: ""
   validation:
     openAPIV3Schema:

--- a/test/bats/vault.bats
+++ b/test/bats/vault.bats
@@ -129,9 +129,6 @@ EOF
 
   cmd="kubectl get secretproviderclasses.secrets-store.csi.x-k8s.io/vault-foo -o yaml | grep vault"
   wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
-
-  cmd="kubectl get all | grep secretproviderclass.secrets-store.csi.x-k8s.io/vault-foo"
-  wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
 }
 
 @test "CSI inline volume test with pod portability" {


### PR DESCRIPTION
- Removing the `all` category as not all users will have the rbac permission to query this. 
- Removing the `secretproviderclass` category as the singular field already handles this